### PR TITLE
Fixed: Setting 'graylogcollectorsidecar::version' to 'latest' is causing the provisioning to fail (issue #2)

### DIFF
--- a/manifests/dist/debian.pp
+++ b/manifests/dist/debian.pp
@@ -21,15 +21,22 @@ class graylogcollectorsidecar::dist::debian (
   } else {
     # Download package
 
+    # Versions have to be downloaded using tags, the latest release not (https://github.com/dodevops/puppet-graylogcollectorsidecar/issues/2)
+    if $version == 'latest' {
+      $is_tag = false
+    } else {
+      $is_tag = true
+    }
+
     githubreleases::download {
       'get_sidecar_package':
         author            => 'Graylog2',
         repository        => 'collector-sidecar',
         release           => $version,
-        is_tag            => true,
+        is_tag            => $is_tag,
         asset             => true,
-        asset_filepattern => "${::architecture}\\.deb",
-        target            => '/tmp/collector-sidecar.deb'
+        asset_filepattern => "${::architecture}\\.rpm",
+        target            => '/tmp/collector-sidecar.rpm'
     }
 
     # Install the package

--- a/manifests/dist/debian.pp
+++ b/manifests/dist/debian.pp
@@ -35,8 +35,8 @@ class graylogcollectorsidecar::dist::debian (
         release           => $version,
         is_tag            => $is_tag,
         asset             => true,
-        asset_filepattern => "${::architecture}\\.rpm",
-        target            => '/tmp/collector-sidecar.rpm'
+        asset_filepattern => "${::architecture}\\.deb",
+        target            => '/tmp/collector-sidecar.deb'
     }
 
     # Install the package

--- a/manifests/dist/redhat.pp
+++ b/manifests/dist/redhat.pp
@@ -21,12 +21,19 @@ class graylogcollectorsidecar::dist::redhat (
   } else {
     # Download package
 
+    # Versions have to be downloaded using tags, the latest release not (https://github.com/dodevops/puppet-graylogcollectorsidecar/issues/2)
+    if $version == 'latest' {
+      $is_tag = false
+    } else {
+      $is_tag = true
+    }
+
     githubreleases::download {
       'get_sidecar_package':
         author            => 'Graylog2',
         repository        => 'collector-sidecar',
         release           => $version,
-        is_tag            => true,
+        is_tag            => $is_tag,
         asset             => true,
         asset_filepattern => "${::architecture}\\.rpm",
         target            => '/tmp/collector-sidecar.rpm'


### PR DESCRIPTION
The easiest solution is to set `is_tag` depending on the value of `version`. A more flexible solution would be to make it configurable (maybe I'll do a follow up PR at some time)