### PR TITLE
Use a different path for creates check if centos 7

### DIFF
--- a/manifests/dist/redhat.pp
+++ b/manifests/dist/redhat.pp
@@ -51,9 +51,20 @@ class graylogcollectorsidecar::dist::redhat (
 
     # Create a sidecar service
 
+    case downcase($::operatingsystemmajrelease) {
+
+      '7': {
+        $check_creates = '/etc/systemd/system/collector-sidecar.service'
+      }
+
+      default: {
+        $check_creates = '/etc/init/collector-sidecar.conf'
+      }
+    }
+
     exec {
       'install_sidecar_service':
-        creates => '/etc/init/collector-sidecar.conf',
+        creates => $check_creates,
         command => 'graylog-collector-sidecar -service install',
         path    => [ '/usr/bin', '/bin' ]
     }

--- a/spec/classes/redhat_spec.rb
+++ b/spec/classes/redhat_spec.rb
@@ -8,7 +8,8 @@ describe 'graylogcollectorsidecar' do
       {
           :osfamily => 'RedHat',
           :architecture => 'x86_64',
-          :installed_sidecar_version => ''
+          :installed_sidecar_version => '',
+          :operatingsystemmajrelease => '7'
       }
     }
 
@@ -47,7 +48,8 @@ describe 'graylogcollectorsidecar' do
       {
           :osfamily => 'RedHat',
           :architecture => 'i386',
-          :installed_sidecar_version => ''
+          :installed_sidecar_version => '',
+          :operatingsystemmajrelease => '7'
       }
     }
 


### PR DESCRIPTION
The `/etc/init` folder doesn't exist in centos version 7

- [x] tested in centos vagrant boxes version 7.1 and 7.3