### PR TITLE
Adding version requirement due to hiera_include

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "dodevops-graylogcollectorsidecar",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "author": "Dennis Ploeger <develop@dieploegers.de>",
   "summary": "Installs and configures the graylog collector sidecar",
   "license": "MIT",
@@ -51,6 +51,12 @@
         "7",
         "8"
       ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": "< 6.0.0"
     }
   ],
   "data_provider": null


### PR DESCRIPTION
Due to used hiera_include function, the puppet version must be limited to lower than 6, because the function got deleted in puppet 6.